### PR TITLE
Make matplotlib optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ license-files = ["LICENSE"]
 description = "Library to match latitude/longitude coordinates to their region, e.g., Longhurst Province"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = ["matplotlib>=3.10.3", "shapely>=2.1.1"]
+dependencies = [
+ "shapely>=2.1.1",
+]
 
 classifiers = [
 	"Programming Language :: Python :: 3",
@@ -49,6 +51,9 @@ sources = ["src"]
 
 [dependency-groups]
 dev = ["pytest>=8.3.5"]
+plot = [
+    "matplotlib>=3.10.3",
+]
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib"]

--- a/scripts/find_region.py
+++ b/scripts/find_region.py
@@ -4,6 +4,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 from latlon_to_region import find_region
+from latlon_to_region.plot_latlon_region import plot_latlon_region
 
 
 def main():
@@ -35,11 +36,10 @@ def main():
     logging.getLogger("matplotlib").setLevel(logging.INFO)
 
     func = find_region()
-    _ = func(
-        args.latitude,
-        args.longitude,
-        plot_file=args.out_file,
-    )
+    _ = func(args.latitude, args.longitude)
+
+    if args.out_file is not None:
+        plot_latlon_region(args.out_file, args.latitude, args.longitude)
 
 
 if __name__ == "__main__":

--- a/src/latlon_to_region/latlon_region.py
+++ b/src/latlon_to_region/latlon_region.py
@@ -48,14 +48,12 @@ Notes
 
 import importlib.resources
 import logging
-import random
 import xml.etree.ElementTree as ET
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import shapely
-import shapely.plotting
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +61,7 @@ logger = logging.getLogger(__name__)
 def find_region(
     provinces: dict[str, dict[str, Any]] | None = None,
 ) -> Callable[
-    [list[float] | float, list[float] | float, str | Path | None],
+    [list[float] | float, list[float] | float],
     list[dict[str, Any] | None] | dict[str, Any] | None,
 ]:
     """Function to match query lat/lon coordinates to their Longhurst Province.
@@ -91,9 +89,7 @@ def find_region(
     provinces_tree, polygons_fids = provinces_make_tree(provinces)
 
     def find_region_func(
-        latitude: list[float] | float,
-        longitude: list[float] | float,
-        plot_file: str | Path | None = None,
+        latitude: list[float] | float, longitude: list[float] | float
     ) -> list[dict[str, Any] | None] | dict[str, Any] | None:
         """Function that takes location(s) in the form of latitude/longitude and
         returns the matching regions
@@ -104,9 +100,6 @@ def find_region(
             Northerly latitude ranging from -90 to 90
         longitude : list of float or float
             Easterly longitude ranging from -180 to 180
-        plot_file: str or None
-            If provided, a map of the provinces and the query coordinates will be
-            plotted and written to this file.
 
         Returns
         -------
@@ -124,9 +117,6 @@ def find_region(
         if isinstance(longitude, float):
             assert not list_passed
             longitude = [longitude]
-
-        if plot_file is not None:
-            _export_figure(plot_file, latitude, longitude, provinces)
 
         regions = _find_region_tree(
             latitude, longitude, provinces, provinces_tree, polygons_fids
@@ -317,38 +307,3 @@ def _find_matching_province_tree(
 
     loc = [shapely.Point(lon, lat) for lat, lon in zip(latitude, longitude)]
     return provincesTree.query(loc, predicate="covered_by").tolist()
-
-
-def _export_figure(
-    filename: Path | str,
-    latitude: list[float],
-    longitude: list[float],
-    provinces: dict[str, dict[str, Any]],
-):
-    import matplotlib.pyplot as plt
-
-    logger.info("plotting...")
-    fig = plt.gcf()
-    fig.set_size_inches(28.5, 20.5)
-    plt.ylim(-75, 75)
-    plt.xlim(-200, 200)
-    for p in provinces.values():
-        polygons = p["provGeoms"]
-        clr = (random.random(), random.random(), random.random())
-        for idx, polygon in enumerate(polygons):
-            center = shapely.centroid(polygon)
-            shapely.plotting.plot_polygon(
-                polygon, color=clr, linewidth=1.0, add_points=False
-            )
-            plt.text(center.x, center.y, p["provCode"] + str(idx), fontsize=12)
-
-    for lat, lon in zip(latitude, longitude):
-        plt.plot(
-            lon,
-            lat,
-            marker="o",
-            markersize=10,
-            markeredgecolor="red",
-            markerfacecolor=(0.0, 1.0, 0.0, 0.5),
-        )
-    plt.savefig(filename, dpi=300)

--- a/src/latlon_to_region/plot_latlon_region.py
+++ b/src/latlon_to_region/plot_latlon_region.py
@@ -1,0 +1,80 @@
+import logging
+import random
+from pathlib import Path
+from typing import Any
+
+import matplotlib.pyplot as plt
+import shapely
+import shapely.plotting
+
+from latlon_to_region import parse_longhurst_xml
+
+logger = logging.getLogger(__name__)
+
+
+def plot_latlon_region(
+    filename: Path | str,
+    latitude: list[float] | float,
+    longitude: list[float] | float,
+    provinces: dict[str, dict[str, Any]] | None = None,
+):
+    """Function that takes location(s) in the form of latitude/longitude and
+    returns the matching regions
+
+    Parameters
+    ----------
+    latitude : list of float or float
+        Northerly latitude ranging from -90 to 90
+    longitude : list of float or float
+        Easterly longitude ranging from -180 to 180
+    plot_file: str or None
+        If provided, a map of the provinces and the query coordinates will be
+        plotted and written to this file.
+
+    Returns
+    -------
+    regions : list of dict or dict or None
+        `dict` with province code (e.g., Longhurst), name, bounding box and
+        polygon, where the coordinate can be found. If the coordinate is on
+        land, or otherwise not associated with a province, `None` will be
+        returned.
+    """
+
+    if provinces is None:
+        provinces = parse_longhurst_xml()
+
+    logger.info("plotting...")
+
+    fig = plt.gcf()
+    fig.set_size_inches(28.5, 20.5)
+    plt.ylim(-75, 75)
+    plt.xlim(-200, 200)
+    for p in provinces.values():
+        polygons = p["provGeoms"]
+        clr = (random.random(), random.random(), random.random())
+        for idx, polygon in enumerate(polygons):
+            center = shapely.centroid(polygon)
+            shapely.plotting.plot_polygon(
+                polygon, color=clr, linewidth=1.0, add_points=False
+            )
+            plt.text(center.x, center.y, p["provCode"] + str(idx), fontsize=12)
+
+    list_passed = True
+    if isinstance(latitude, float):
+        list_passed = False
+        latitude = [latitude]
+        assert isinstance(longitude, float)
+    if isinstance(longitude, float):
+        assert not list_passed
+        longitude = [longitude]
+
+    for lat, lon in zip(latitude, longitude):
+        plt.plot(
+            lon,
+            lat,
+            marker="o",
+            markersize=10,
+            markeredgecolor="red",
+            markerfacecolor=(0.0, 1.0, 0.0, 0.5),
+        )
+    plt.savefig(filename, dpi=300)

--- a/uv.lock
+++ b/uv.lock
@@ -150,7 +150,6 @@ wheels = [
 name = "latlon-to-region"
 source = { editable = "." }
 dependencies = [
-    { name = "matplotlib" },
     { name = "shapely" },
 ]
 
@@ -163,10 +162,12 @@ ci = [
 dev = [
     { name = "pytest" },
 ]
+plot = [
+    { name = "matplotlib" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "matplotlib", specifier = ">=3.10.3" },
     { name = "pytest", marker = "extra == 'ci'", specifier = ">=8.3.5" },
     { name = "shapely", specifier = ">=2.1.1" },
 ]
@@ -174,6 +175,7 @@ provides-extras = ["ci"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.3.5" }]
+plot = [{ name = "matplotlib", specifier = ">=3.10.3" }]
 
 [[package]]
 name = "matplotlib"


### PR DESCRIPTION
remove matplotlib as a required dependency for the base functionality of latlon-region conversion.
- move the plotting function to a separate module
- add a separate dependency group for matplotlib